### PR TITLE
Allow to disable "Add OpenJDK-R Java PPA" task

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Role Variables
 | java_openjdk_version           | 8       | Version of OpenJDK Java to install                    |
 | java_openjdk_headless          | false   | Select 'Complete' vs 'Headless' install for OpenJDK   |
 | java_openjdk_jre_only          | false   | Select JDK vs Java Runtime Environment for OpenJDK    |
+| java_openjdk_use_ppa           | true    | Add the OpenJDK-R Java PPA to repositories list       |
 | java_oracle_version            | 8       | Version of Oracle Java to install                     |
 | java_oracle_install_jce_policy | false   | Enable/Disable installation of Oracle Java JCE policy |
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ java_implementation: openjdk
 java_openjdk_version: 8
 java_openjdk_jre_only: false
 java_openjdk_headless: false
+java_openjdk_use_ppa: true
 
 java_oracle_version: 8
 java_oracle_install_jce_policy: false

--- a/tasks/Ubuntu.yml
+++ b/tasks/Ubuntu.yml
@@ -5,7 +5,7 @@
   apt_repository: >
     repo='ppa:openjdk-r/ppa'
     state=present
-  when: java_implementation == "openjdk"
+  when: java_implementation == "openjdk" and java_openjdk_use_ppa
   tags: java
 
 - name: Install OpenJDK Java


### PR DESCRIPTION
When using the role behind a corporate firewall, or when intending to
install Java only from the packages available in the distribution, we
don't want to add the OpenJDK PPA to the repositories list.

Add a new variable, java_openjdk_use_ppa, which will prevent this task
from running when set to false. The default value is true, meaning the
default behaviour is unchanged.

Change-Id: I087c95f0742925a7adf998c9a563489526dd6c56
