### PR TITLE
Changed 'include' to 'include_tasks'

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,12 +6,12 @@
   tags:
     - java
 
-- include: CentOS.yml
+- include_tasks: CentOS.yml
   when: ansible_distribution == "CentOS"
   tags:
     - java
 
-- include: Ubuntu.yml
+- include_tasks: Ubuntu.yml
   when: ansible_distribution == "Ubuntu"
   tags:
     - java


### PR DESCRIPTION
as 'include' will be deprecated in ansible v2.8 changed 'include' to 'include_tasks'